### PR TITLE
Add `files` Action Input

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -87,3 +87,35 @@ jobs:
 
       - name: Test Solutions Should Be Failing
         run: exit ${{ steps.test-solutions.outcome == 'success' && '1' || '0' }}
+
+  test-action-with-files-specified:
+    name: Test Action With Files Specified
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows, ubuntu, macos]
+    steps:
+      - name: Checkout Solutions
+        uses: actions/checkout@v4.1.2
+        with:
+          repository: threeal/leetspace-starter
+
+      - name: Modify Solutions
+        run: |
+          cp -r problems/2235 problems/2236
+          echo "something" >> problems/2235/solution.cpp
+
+      - name: Checkout Action
+        uses: actions/checkout@v4.1.2
+        with:
+          path: leettest-action
+          sparse-checkout: |
+            action.yml
+            dist
+          sparse-checkout-cone-mode: false
+
+      - name: Test Solutions
+        uses: ./leettest-action
+        with:
+          files: problems/2236/solution.cpp

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Compile and test solutions to [LeetCode](https://leetcode.com/) problems on GitHub Actions.
 
+## Available Inputs
+
+| Name    | Type             | Description                                                                        |
+| ------- | ---------------- | ---------------------------------------------------------------------------------- |
+| `files` | Multiple strings | A list of pattern for solution files to process. It defaults to `**/solution.cpp`. |
+
 ## License
 
 This project is licensed under the terms of the [MIT License](./LICENSE).

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,10 @@ description: Compile and test solutions to LeetCode problems
 branding:
   icon: zap
   color: black
+inputs:
+  files:
+    description: A list of pattern for solution files to process
+    default: "**/solution.cpp"
 runs:
   using: node20
   main: dist/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -24985,7 +24985,10 @@ __nccwpck_require__.a(module, async (__webpack_handle_async_dependencies__, __we
 
 
 try {
-    const solutionFiles = (0,glob__WEBPACK_IMPORTED_MODULE_1__/* .globSync */ .Pv)("**/solution.cpp").sort();
+    const solutionFiles = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getMultilineInput)("files")
+        .map((pattern) => (0,glob__WEBPACK_IMPORTED_MODULE_1__/* .globSync */ .Pv)(pattern))
+        .flat()
+        .sort();
     const task = new listr2__WEBPACK_IMPORTED_MODULE_3__/* .Listr */ .A4(solutionFiles.map((solutionFile) => ({
         title: `Testing ${solutionFile}...`,
         task: (_, task) => task.newListr((0,leettest__WEBPACK_IMPORTED_MODULE_2__/* .createTestCppSolutionTasks */ .Q)(solutionFile), {
@@ -25004,11 +25007,11 @@ try {
     });
     await task.run();
     if (task.errors.length > 0) {
-        _actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed(`failed to test ${task.errors.length} solutions`);
+        (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed)(`failed to test ${task.errors.length} solutions`);
     }
 }
 catch (err) {
-    _actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed(err);
+    (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed)(err);
 }
 
 __webpack_async_result__();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,13 @@
-import * as core from "@actions/core";
+import { getMultilineInput, setFailed } from "@actions/core";
 import { globSync } from "glob";
 import { createTestCppSolutionTasks } from "leettest";
 import { Listr, ListrTask } from "listr2";
 
 try {
-  const solutionFiles = globSync("**/solution.cpp").sort();
+  const solutionFiles = getMultilineInput("files")
+    .map((pattern) => globSync(pattern))
+    .flat()
+    .sort();
   const task = new Listr(
     solutionFiles.map(
       (solutionFile): ListrTask => ({
@@ -29,8 +32,8 @@ try {
   );
   await task.run();
   if (task.errors.length > 0) {
-    core.setFailed(`failed to test ${task.errors.length} solutions`);
+    setFailed(`failed to test ${task.errors.length} solutions`);
   }
 } catch (err) {
-  core.setFailed(err);
+  setFailed(err);
 }


### PR DESCRIPTION
This pull request resolves #23 by introducing the following changes:
- Adding a new `files` action input for specifying a list of patterns for solution files to process.
- Adding a new `test-action-with-files-specified` job in the `test` workflow to test the behavior of the `files` action input.
- Adding a new "Available Inputs" section in the `README.md` file.