### PR TITLE
Add Example Usages to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ jobs:
         uses: threeal/leettest-action@v0.2.0
 ```
 
+### Testing Specific Solution Files
+
+By default, this action tests all solution files in the current working directory. To specify the solution files to test, set the `files` input:
+
+```yaml
+- name: Test Solutions
+  uses: threeal/leettest-action@v0.2.0
+  with:
+    files: |
+      problems/2235/solution.cpp
+      other-problems/**/solution.cpp
+```
+
 ## License
 
 This project is licensed under the terms of the [MIT License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -8,6 +8,26 @@ Compile and test solutions to [LeetCode](https://leetcode.com/) problems on GitH
 | ------- | ---------------- | ---------------------------------------------------------------------------------- |
 | `files` | Multiple strings | A list of pattern for solution files to process. It defaults to `**/solution.cpp`. |
 
+## Example Usages
+
+This example demonstrates how to use this action to compile and test solutions to LeetCode problems in a GitHub Actions workflow:
+
+```yaml
+name: Test
+on:
+  push:
+jobs:
+  test-solutions:
+    name: Test Solutions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.4
+
+      - name: Test Solutions
+        uses: threeal/leettest-action@v0.2.0
+```
+
 ## License
 
 This project is licensed under the terms of the [MIT License](./LICENSE).


### PR DESCRIPTION
This pull request resolves #31 by adding an Example Usages section to the `README.md` file.