### PR TITLE
Enable TypeScript Strict Configuration

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -25648,9 +25648,11 @@ exports["default"] = _default;
 __nccwpck_require__.a(module, async (__webpack_handle_async_dependencies__, __webpack_async_result__) => { try {
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(2340);
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(_actions_core__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var catched_error_message__WEBPACK_IMPORTED_MODULE_4__ = __nccwpck_require__(144);
 /* harmony import */ var glob__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(7868);
 /* harmony import */ var leettest__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(1740);
 /* harmony import */ var listr2__WEBPACK_IMPORTED_MODULE_3__ = __nccwpck_require__(4094);
+
 
 
 
@@ -25682,7 +25684,7 @@ try {
     }
 }
 catch (err) {
-    (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed)(err);
+    (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed)((0,catched_error_message__WEBPACK_IMPORTED_MODULE_4__/* .getErrorMessage */ .e)(err));
 }
 
 __webpack_async_result__();
@@ -35866,6 +35868,18 @@ function replaceNode(key, path, node) {
 
 exports.visit = visit;
 exports.visitAsync = visitAsync;
+
+
+/***/ }),
+
+/***/ 144:
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __nccwpck_require__) => {
+
+/* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
+/* harmony export */   "e": () => (/* binding */ r)
+/* harmony export */ });
+function r(r){return function(r){if("object"==typeof(e=r)&&null!==e&&"message"in e&&"string"==typeof e.message)return r;var e;try{return new Error(JSON.stringify(r))}catch(e){return new Error(String(r))}}(r).message}
+//# sourceMappingURL=index.esm.js.map
 
 
 /***/ }),

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@actions/core": "^1.10.1",
+    "catched-error-message": "^0.0.1",
     "glob": "^11.0.0",
     "leettest": "^0.2.0",
     "listr2": "^8.2.1"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { getMultilineInput, setFailed } from "@actions/core";
+import { getErrorMessage } from "catched-error-message";
 import { globSync } from "glob";
 import { createTestCppSolutionTasks } from "leettest";
 import { Listr, ListrTask } from "listr2";
@@ -35,5 +36,5 @@ try {
     setFailed(`failed to test ${task.errors.length} solutions`);
   }
 } catch (err) {
-  setFailed(err);
+  setFailed(getErrorMessage(err));
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "node16",
     "moduleResolution": "node16",
     "esModuleInterop": true,
-    "target": "es2022"
+    "target": "es2022",
+    "skipLibCheck": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
+    "strict": true,
     "module": "node16",
     "moduleResolution": "node16",
     "esModuleInterop": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1408,6 +1408,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"catched-error-message@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "catched-error-message@npm:0.0.1"
+  checksum: 10c0/1f10cd4323a73bec7a57b7495730e5dad9995120b04e85b5f654f7b40dc6a36320d95cc55e49cdf78753158e18790ef725e2ec7309ebced3acd6c9a557ac075b
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^2.4.2":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
@@ -3419,6 +3426,7 @@ __metadata:
     "@jest/globals": "npm:^29.7.0"
     "@types/node": "npm:^22.0.0"
     "@vercel/ncc": "npm:^0.38.1"
+    catched-error-message: "npm:^0.0.1"
     eslint: "npm:^9.8.0"
     glob: "npm:^11.0.0"
     leettest: "npm:^0.2.0"


### PR DESCRIPTION
This pull request resolves #110 by introducing the following changes:
- Uses the [catched-error-message](https://www.npmjs.com/package/catched-error-message) package to stringify caught errors.
- Enables TypeScript strict configuration.
- Configures TypeScript to skip library checks.