### PR TITLE
Fix Build Stuck in Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,11 @@ jobs:
         uses: threeal/setup-yarn-action@v2.0.0
 
       - name: Build Package
-        run: yarn build
+        uses: nick-fields/retry@v3.0.2
+        with:
+          timeout_minutes: 1
+          max_attempts: 5
+          command: yarn build
 
       - name: Check Diff
         run: git diff && git diff-index --quiet --exit-code HEAD


### PR DESCRIPTION
This pull request resolves #323 by fixing the issue of the build getting stuck in CI by disabling caching.