### PR TITLE
Integrate Lefthook

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           timeout_minutes: 1
           max_attempts: 5
-          command: pnpm build
+          command: pnpm rollup -c
 
       - name: Check Diff
-        run: git diff && git diff-index --quiet --exit-code HEAD
+        run: git diff --exit-code dist

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -19,10 +19,10 @@ jobs:
         run: pnpm install
 
       - name: Check Formatting
-        run: pnpm format
-
-      - name: Check Diff
-        run: git diff && git diff-index --quiet --exit-code HEAD
+        run: pnpm prettier --check .
 
       - name: Check Lint
-        run: pnpm lint
+        run: pnpm eslint
+
+      - name: Check Types
+        run: pnpm tsc --noEmit

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
+dist
 pnpm-lock.yaml

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,40 @@
+pre-commit:
+  piped: true
+  jobs:
+    - name: install dependencies
+      run: pnpm install
+      glob:
+        - package.json
+        - pnpm-lock.yaml
+        - pnpm-workspace.yaml
+
+    - name: fix formatting
+      run: pnpm prettier --write --ignore-unknown {staged_files}
+
+    - name: fix lint
+      run: pnpm eslint --no-warn-ignored --fix {staged_files}
+
+    - name: check types
+      run: pnpm tsc --noEmit
+      glob:
+        - src/*.ts
+        - .npmrc
+        - pnpm-lock.yaml
+        - tsconfig.json
+      exclude:
+        - src/*.test.ts
+
+    - name: build action
+      run: pnpm rollup -c
+      glob:
+        - dist/*
+        - src/*.ts
+        - .npmrc
+        - pnpm-lock.yaml
+        - rollup.config.js
+        - tsconfig.json
+      exclude:
+        - src/*.test.ts
+
+    - name: check diff
+      run: git diff --exit-code dist {staged_files}

--- a/package.json
+++ b/package.json
@@ -2,11 +2,6 @@
   "name": "root",
   "private": true,
   "type": "module",
-  "scripts": {
-    "build": "rollup -c",
-    "format": "prettier --write --cache .",
-    "lint": "eslint"
-  },
   "dependencies": {
     "gha-utils": "^0.4.1",
     "glob": "^11.0.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "rollup -c",
-    "format": "prettier --write --cache . !dist",
+    "format": "prettier --write --cache .",
     "lint": "eslint"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@tsconfig/node23": "^23.0.2",
     "@types/node": "^22.15.21",
     "eslint": "^9.27.0",
+    "lefthook": "^1.11.13",
     "prettier": "^3.5.3",
     "rollup": "^4.41.1",
     "tslib": "^2.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       eslint:
         specifier: ^9.27.0
         version: 9.27.0
+      lefthook:
+        specifier: ^1.11.13
+        version: 1.11.13
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
@@ -1119,6 +1122,60 @@ packages:
 
   leettest@0.2.0:
     resolution: {integrity: sha512-y6llghciQBrc3FHiXxtpYjWdqofic0dr3DlCYny+dEB4DnMstfgNgJLNB211FD9uWtrEW1uzDf9ekjrP/DI41g==}
+    hasBin: true
+
+  lefthook-darwin-arm64@1.11.13:
+    resolution: {integrity: sha512-gHwHofXupCtzNLN+8esdWfFTnAEkmBxE/WKA0EwxPPJXdZYa1GUsiG5ipq/CdG/0j8ekYyM9Hzyrrk5BqJ42xw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@1.11.13:
+    resolution: {integrity: sha512-zYxkWNUirmTidhskY9J9AwxvdMi3YKH+TqZ3AQ1EOqkOwPBWJQW5PbnzsXDrd3YnrtZScYm/tE/moXJpEPPIpQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@1.11.13:
+    resolution: {integrity: sha512-gJzWnllcMcivusmPorEkXPpEciKotlBHn7QxWwYaSjss/U3YdZu+NTjDO30b3qeiVlyq4RAZ4BPKJODXxHHwUA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@1.11.13:
+    resolution: {integrity: sha512-689XdchgtDvZQWFFx1szUvm/mqrq/v6laki0odq5FAfcSgUeLu3w+z6UicBS5l55eFJuQTDNKARFqrKJ04e+Vw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@1.11.13:
+    resolution: {integrity: sha512-ujCLbaZg5S/Ao8KZAcNSb+Y3gl898ZEM0YKyiZmZo22dFFpm/5gcV46pF3xaqIw5IpH+3YYDTKDU+qTetmARyQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@1.11.13:
+    resolution: {integrity: sha512-O5WdodeBtFOXQlvPcckqp4W/yqVM9DbVQBkvOxwSJlmsxO4sGYK1TqdxH9ihLB85B2kPPssZj9ze36/oizzhVQ==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@1.11.13:
+    resolution: {integrity: sha512-SyBpciUfvY/lUDbZu7L6MtL/SVG2+yMTckBgb4PdJQhJlisY0IsyOYdlTw2icPPrY7JnwdsFv8UW0EJOB76W4g==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@1.11.13:
+    resolution: {integrity: sha512-6+/0j6O2dzo9cjTWUKfL2J6hRR7Krna/ssqnW8cWh8QHZKO9WJn34epto9qgjeHwSysou8byI7Mwv5zOGthLCQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@1.11.13:
+    resolution: {integrity: sha512-w5TwZ8bsZ17uOMtYGc5oEb4tCHjNTSeSXRy6H9Yic8E7IsPZtZLkaZGnIIwgXFuhhrcCdc6FuTvKt2tyV7EW2g==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@1.11.13:
+    resolution: {integrity: sha512-7lvwnIs8CNOXKU4y3i1Pbqna+QegIORkSD2VCuHBNpIJ8H84NpjoG3tKU91IM/aI1a2eUvCk+dw+1rfMRz7Ytg==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@1.11.13:
+    resolution: {integrity: sha512-SDTk3D4nW1XRpR9u9fdYQ/qj1xeZVIwZmIFdJUnyq+w9ZLdCCvIrOmtD8SFiJowSevISjQDC+f9nqyFXUxc0SQ==}
     hasBin: true
 
   levn@0.4.1:
@@ -2702,6 +2759,49 @@ snapshots:
       listr2: 8.3.3
       yaml: 2.7.0
       yargs: 17.7.2
+
+  lefthook-darwin-arm64@1.11.13:
+    optional: true
+
+  lefthook-darwin-x64@1.11.13:
+    optional: true
+
+  lefthook-freebsd-arm64@1.11.13:
+    optional: true
+
+  lefthook-freebsd-x64@1.11.13:
+    optional: true
+
+  lefthook-linux-arm64@1.11.13:
+    optional: true
+
+  lefthook-linux-x64@1.11.13:
+    optional: true
+
+  lefthook-openbsd-arm64@1.11.13:
+    optional: true
+
+  lefthook-openbsd-x64@1.11.13:
+    optional: true
+
+  lefthook-windows-arm64@1.11.13:
+    optional: true
+
+  lefthook-windows-x64@1.11.13:
+    optional: true
+
+  lefthook@1.11.13:
+    optionalDependencies:
+      lefthook-darwin-arm64: 1.11.13
+      lefthook-darwin-x64: 1.11.13
+      lefthook-freebsd-arm64: 1.11.13
+      lefthook-freebsd-x64: 1.11.13
+      lefthook-linux-arm64: 1.11.13
+      lefthook-linux-x64: 1.11.13
+      lefthook-openbsd-arm64: 1.11.13
+      lefthook-openbsd-x64: 1.11.13
+      lefthook-windows-arm64: 1.11.13
+      lefthook-windows-x64: 1.11.13
 
   levn@0.4.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+onlyBuiltDependencies:
+  - lefthook


### PR DESCRIPTION
This pull request resolves #381 by integrating [Lefthook](https://lefthook.dev/) into this project, allowing pre-commit hooks to be installed and executed on staged files. In doing so, this change also removes the `build`, `format`, and `lint` scripts as they are no longer necessary.