### PR TITLE
Add Missing `packages` Field in `pnpm-workspace.yaml`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
+packages: [.]
 onlyBuiltDependencies:
   - lefthook


### PR DESCRIPTION
This pull request resolves #419 by adding a missing `packages` field in the `pnpm-workspace.yaml` file.