### PR TITLE
Remove Glob Pattern for Filtering Lefthook Jobs

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -17,4 +17,4 @@ pre-commit:
       run: rm -rf dist && pnpm rollup -c
 
     - name: check diff
-      run: git diff --exit-code dist {staged_files}
+      run: git diff --exit-code dist pnpm-lock.yaml {staged_files}


### PR DESCRIPTION
This pull request resolves #451 by removing the glob pattern used to filter Lefthook jobs. It also modifies jobs to process all files and adds the `pnpm-lock.yaml` file to the list of files checked for changes.