### PR TITLE
Remove `packages` option from `pnpm-workspace.yaml`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,2 @@
-packages: [.]
 allowBuilds:
   lefthook: true


### PR DESCRIPTION
This pull request resolves #604 by removing the `packages` option from `pnpm-workspace.yaml`, simplifying the workspace configuration.